### PR TITLE
Track Attribution data

### DIFF
--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
@@ -10,15 +10,13 @@
 #import <Analytics/SEGIntegration.h>
 #import <AppsFlyer/AppsFlyer.h>
 
-@interface SEGAppsFlyerIntegration : NSObject <SEGIntegration>
+@interface SEGAppsFlyerIntegration : NSObject <SEGIntegration, AppsFlyerTrackerDelegate>
 
 @property (nonatomic, strong) NSDictionary *settings;
 @property (nonatomic, strong) AppsFlyerTracker *appsflyer;
+@property (nonatomic, strong) SEGAnalytics *analytics;
 
 
-
-- (instancetype)initWithSettings:(NSDictionary *)settings;
-- (instancetype)initWithSettings:(NSDictionary *)settings withAppsflyer:(AppsFlyerTracker *)aAppsflyer;
-
+- (instancetype)initWithSettings:(NSDictionary *)settings withAnalytics:(SEGAnalytics *) analytics;
 
 @end

--- a/segment-appsflyer-ios/Classes/SegAppsFlyerIntegrationFactory.m
+++ b/segment-appsflyer-ios/Classes/SegAppsFlyerIntegrationFactory.m
@@ -30,7 +30,7 @@
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings];
+    return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics];
 }
 
 - (NSString *)key


### PR DESCRIPTION
This feature will let users record attribution data and send it to Segment as an event, which in turn will also send it to other tools integrated with Segment.

See https://segment.com/docs/spec/mobile/#install-attributed.
Also see https://github.com/AppsFlyerSDK/AppsFlyer-Segment-Integration/pull/4

I removed the initWithAppsFlyer initializer because it was unused as far
as I could tell.