### PR TITLE
Set nil campaign values to empty string

### DIFF
--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
@@ -120,9 +120,9 @@
 
 -(void)onConversionDataReceived:(NSDictionary *)installData {
       NSDictionary *campaign = @{
-                @"source": installData[@"media_source"],
-                @"name": installData[@"campaign"],
-                @"adGroup": installData[@"adgroup"]
+                @"source": installData[@"media_source"] ? installData[@"media_source"] : @"",
+                @"name": installData[@"campaign"] ? installData[@"campaign"] : @"",
+                @"adGroup": installData[@"adgroup"] ? installData[@"adgroup"] : @""
       };
 
       NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:@{


### PR DESCRIPTION
In a Swift 2.3 project, compiled against iOS 10, a crash was observed when the `campaign` dictionary contained nil values. This will be the case for organic installs. The crash observed was:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]'
```

This PR simply provides fallbacks to empty strings if the install data value is nil.