### PR TITLE
Compatibility with AppsFlyer SDK v4.5.12

### DIFF
--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGAnalytics.h>
-#import <AppsFlyerTracker/AppsFlyerTracker.h>
+#import <AppsFlyerLib/AppsFlyerTracker.h>
 
 @interface SEGAppsFlyerIntegration : NSObject <SEGIntegration, AppsFlyerTrackerDelegate>
 

--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
@@ -150,7 +150,7 @@
     
     // Delete already mapped special fields.
     [properties removeObjectForKey:@"media_source"];
-    [properties removeObjectForKey:@"campagin"];
+    [properties removeObjectForKey:@"campaign"];
     [properties removeObjectForKey:@"adgroup"];
     
     [self.analytics track:@"Install Attributed" properties:[properties copy]];


### PR DESCRIPTION
Seems the AppsFlyer SDK Version 4.5.12 has changed include paths from `AppsFlyerTracker/AppsFlyerTracker.h` to `AppsFlyerLib/AppsFlyerTracker`. This patch fixes the Segment integration.