### PR TITLE
Fix AppsFlyer library import

### DIFF
--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGAnalytics.h>
-#import <AppsFlyerTracker/AppsFlyerTracker.h>
+#import <AppsFlyerLib/AppsFlyerTracker.h>
 
 
 @interface SEGAppsFlyerIntegration : NSObject <SEGIntegration, AppsFlyerTrackerDelegate>


### PR DESCRIPTION
The latest AppsFlyer SDK has changed the required import statement from:

#import <AppsFlyerTracker/AppsFlyerTracker.h>

to:

#import <AppsFlyerLib/AppsFlyerTracker.h>

So the integration will no longer compile. This should fix the issue.