### PR TITLE
Use correct casing to avoid warning in Xcode 8.3

### DIFF
--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/AppDelegate.h
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/AppDelegate.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "SEGAppsFlyerIntegrationFactory.h"
+#import "SegAppsFlyerIntegrationFactory.h"
 #import <Analytics/SEGAnalytics.h>
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SegAppsFlyerIntegrationFactory.m
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SegAppsFlyerIntegrationFactory.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
-#import "SEGAppsFlyerIntegrationFactory.h"
+#import "SegAppsFlyerIntegrationFactory.h"
 #import "SEGAppsFlyerIntegration.h"
 
 

--- a/examples/TestAppSegmentSwift/TestAppSegmentSwift/SegAppsFlyerIntegrationFactory.m
+++ b/examples/TestAppSegmentSwift/TestAppSegmentSwift/SegAppsFlyerIntegrationFactory.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
-#import "SEGAppsFlyerIntegrationFactory.h"
+#import "SegAppsFlyerIntegrationFactory.h"
 #import "SEGAppsFlyerIntegration.h"
 
 

--- a/examples/TestAppSegmentSwift/TestAppSegmentSwift/TestAppSegmentSwift-Bridging-Header.h
+++ b/examples/TestAppSegmentSwift/TestAppSegmentSwift/TestAppSegmentSwift-Bridging-Header.h
@@ -1,2 +1,2 @@
 
-#import "SEGAppsFlyerIntegrationFactory.h"
+#import "SegAppsFlyerIntegrationFactory.h"

--- a/segment-appsflyer-ios/Classes/SegAppsFlyerIntegrationFactory.m
+++ b/segment-appsflyer-ios/Classes/SegAppsFlyerIntegrationFactory.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
-#import "SEGAppsFlyerIntegrationFactory.h"
+#import "SegAppsFlyerIntegrationFactory.h"
 #import "SEGAppsFlyerIntegration.h"
 
 


### PR DESCRIPTION
Within Xcode 8.3 the default set of warnings emits a warning based on inconsistent casting with the file system and things specified in import paths. This just changes the casing to match the included files.

| Error | 
|---|
| <img width="394" alt="screen shot 2017-03-27 at 6 12 18 pm" src="https://cloud.githubusercontent.com/assets/63919/24380468/79b92114-1319-11e7-8141-7b82d737882f.png"> | 
