### PR TITLE
Dev/rd 5224/on conversion data received

### DIFF
--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/AppDelegate.h
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/AppDelegate.h
@@ -10,7 +10,7 @@
 #import "SEGAppsFlyerIntegrationFactory.h"
 #import <Analytics/SEGAnalytics.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, SEGAppsFlyerTrackerDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/AppDelegate.m
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/AppDelegate.m
@@ -20,7 +20,9 @@
     
     SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"GRN6QWnSb8tbDETvKXwLQDEVomHmHuDO"];
     
-    [config use:[SEGAppsFlyerIntegrationFactory instance]];
+    //[config use:[SEGAppsFlyerIntegrationFactory instance]];
+
+    [config use:[SEGAppsFlyerIntegrationFactory createWithLaunchDelegate:self]];
     
     config.enableAdvertisingTracking = YES;
     config.trackApplicationLifecycleEvents = YES;
@@ -60,6 +62,45 @@
 - (void)applicationWillTerminate:(UIApplication *)application {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
+
+-(void)onConversionDataReceived:(NSDictionary*) installData {
+    
+    NSLog(@"FESS :: onConversionDataReceived is called");
+    
+    id status = [installData objectForKey:@"af_status"];
+    
+    if([status isEqualToString:@"Non-organic"]) {
+        
+        id sourceID = [installData objectForKey:@"media_source"];
+        
+        id campaign = [installData objectForKey:@"campaign"];
+        
+        NSLog(@"This is a none organic install. Media source: %@  Campaign: %@",sourceID,campaign);
+        
+    } else if([status isEqualToString:@"Organic"]) {
+        
+        NSLog(@"This is an organic install.");
+        
+    }
+    
+}
+
+-(void)onConversionDataRequestFailure:(NSError *) error {
+    
+    NSLog(@"%@",error);
+}
+
+
+- (void) onAppOpenAttribution:(NSDictionary*) attributionData {
+    
+    NSLog(@"attribution data: %@", attributionData);
+}
+
+- (void) onAppOpenAttributionFailure:(NSError *)error {
+    NSLog(@"%@",error);
+    
+}
+
 
 
 @end

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegration.h
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegration.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGAnalytics.h>
 #import <AppsFlyerLib/AppsFlyerTracker.h>
-//#import "SEGAppsFlyerIntegrationFactory.h"
 
 @protocol SEGAppsFlyerTrackerDelegate <AppsFlyerTrackerDelegate>
 

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegration.h
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegration.h
@@ -9,15 +9,26 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGAnalytics.h>
 #import <AppsFlyerLib/AppsFlyerTracker.h>
+//#import "SEGAppsFlyerIntegrationFactory.h"
 
+@protocol SEGAppsFlyerTrackerDelegate <AppsFlyerTrackerDelegate>
+
+@end
 
 @interface SEGAppsFlyerIntegration : NSObject <SEGIntegration, AppsFlyerTrackerDelegate>
 
 @property (nonatomic, strong) NSDictionary *settings;
 @property (nonatomic, strong) AppsFlyerTracker *appsflyer;
 @property (nonatomic, strong) SEGAnalytics *analytics;
+@property (unsafe_unretained, nonatomic) id<SEGAppsFlyerTrackerDelegate> segDelegate;
+
+- (instancetype)initWithSettings:(NSDictionary *)settings
+                   withAnalytics:(SEGAnalytics *) analytics;
+
+- (instancetype)initWithSettings:(NSDictionary *)settings
+                   withAnalytics:(SEGAnalytics *)analytics
+                andDelegate:(id<AppsFlyerTrackerDelegate>) delegate;
 
 
-- (instancetype)initWithSettings:(NSDictionary *)settings withAnalytics:(SEGAnalytics *) analytics;
 - (void) trackLaunch;
 @end

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.h
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.h
@@ -8,9 +8,17 @@
 
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
+#import <AppsFlyerLib/AppsFlyerTracker.h>
+#import "SEGAppsFlyerIntegration.h"
+
 
 @interface SEGAppsFlyerIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 + (instancetype)instance;
+//+ (instancetype)createWithLaunchOptions:(NSString *)token launchOptions:(NSDictionary *)launchOptions;
++ (instancetype)createWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate;
+
+//@property NSDictionary *launchOptions;
+@property (unsafe_unretained, nonatomic) id<SEGAppsFlyerTrackerDelegate> delegate;
 
 @end

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.h
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.h
@@ -8,17 +8,14 @@
 
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
-#import <AppsFlyerLib/AppsFlyerTracker.h>
 #import "SEGAppsFlyerIntegration.h"
 
 
 @interface SEGAppsFlyerIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 + (instancetype)instance;
-//+ (instancetype)createWithLaunchOptions:(NSString *)token launchOptions:(NSDictionary *)launchOptions;
 + (instancetype)createWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate;
 
-//@property NSDictionary *launchOptions;
 @property (unsafe_unretained, nonatomic) id<SEGAppsFlyerTrackerDelegate> delegate;
 
 @end

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.m
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.m
@@ -7,7 +7,6 @@
 //
 
 #import "SEGAppsFlyerIntegrationFactory.h"
-//#import "SEGAppsFlyerIntegration.h"
 
 
 @implementation SEGAppsFlyerIntegrationFactory : NSObject
@@ -44,7 +43,6 @@
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    //return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics];
     return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics
                                             andDelegate:self.delegate];
 }

--- a/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.m
+++ b/examples/TestAppSegmentObjC/TestAppSegmentObjC/SEGAppsFlyerIntegrationFactory.m
@@ -7,7 +7,7 @@
 //
 
 #import "SEGAppsFlyerIntegrationFactory.h"
-#import "SEGAppsFlyerIntegration.h"
+//#import "SEGAppsFlyerIntegration.h"
 
 
 @implementation SEGAppsFlyerIntegrationFactory : NSObject
@@ -17,7 +17,7 @@
     static dispatch_once_t once;
     static SEGAppsFlyerIntegrationFactory *sharedInstance;
     dispatch_once(&once, ^{
-        sharedInstance = [[self alloc] init];
+        sharedInstance = [[self alloc] initWithLaunchDelegate:nil];
     });
     return sharedInstance;
 }
@@ -28,9 +28,25 @@
     return self;
 }
 
+- (instancetype)initWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate
+{
+    if (self = [super init]) {
+        self.delegate = delegate;
+    }
+    return self;
+}
+
+
++ (instancetype)createWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate
+{
+    return [[self alloc] initWithLaunchDelegate:delegate];
+}
+
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics];
+    //return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics];
+    return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics
+                                            andDelegate:self.delegate];
 }
 
 - (NSString *)key

--- a/examples/TestAppSegmentObjC/podfile
+++ b/examples/TestAppSegmentObjC/podfile
@@ -1,5 +1,5 @@
 use_frameworks!
 target 'TestAppSegmentObjC' do
-  pod 'AppsFlyerFramework'
+  pod 'AppsFlyerFramework', '4.7.3'
   pod 'Analytics', '~> 3.5'
 end

--- a/examples/TestAppSegmentSwift/TestAppSegmentSwift/SEGAppsFlyerIntegration.m
+++ b/examples/TestAppSegmentSwift/TestAppSegmentSwift/SEGAppsFlyerIntegration.m
@@ -136,24 +136,32 @@
 }
 
 -(void)onConversionDataReceived:(NSDictionary *)installData {
-    NSDictionary *campaign = @{
-                               @"source": installData[@"media_source"] ? installData[@"media_source"] : @"",
-                               @"name": installData[@"campaign"] ? installData[@"campaign"] : @"",
-                               @"adGroup": installData[@"adgroup"] ? installData[@"adgroup"] : @""
-                               };
+    NSString *const key = @"AF_Install_Attr_Sent";
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    BOOL installAttrSent = [userDefaults boolForKey:key];
     
-    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:@{
-                                                                                      @"provider": @"AppsFlyer",
-                                                                                      @"campaign": campaign,
-                                                                                      }];
-    [properties addEntriesFromDictionary:installData];
-    
-    // Delete already mapped special fields.
-    [properties removeObjectForKey:@"media_source"];
-    [properties removeObjectForKey:@"campaign"];
-    [properties removeObjectForKey:@"adgroup"];
-    
-    [self.analytics track:@"Install Attributed" properties:[properties copy]];
+    if(!installAttrSent){
+        NSDictionary *campaign = @{
+                                   @"source": installData[@"media_source"] ? installData[@"media_source"] : @"",
+                                   @"name": installData[@"campaign"] ? installData[@"campaign"] : @"",
+                                   @"adGroup": installData[@"adgroup"] ? installData[@"adgroup"] : @""
+                                   };
+        
+        NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                          @"provider": @"AppsFlyer",
+                                                                                          @"campaign": campaign,
+                                                                                          }];
+        [properties addEntriesFromDictionary:installData];
+        
+        // Delete already mapped special fields.
+        [properties removeObjectForKey:@"media_source"];
+        [properties removeObjectForKey:@"campaign"];
+        [properties removeObjectForKey:@"adgroup"];
+        
+        [self.analytics track:@"Install Attributed" properties:[properties copy]];
+        
+        [userDefaults setBool:YES forKey:key];
+    }
 }
 
 -(void)onConversionDataRequestFailure:(NSError *) error {

--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
@@ -2,7 +2,7 @@
 //  SEGAppsFlyerIntegration.h
 //  AppsFlyerSegmentiOS
 //
-//  Created by Golan on 5/17/16.
+//  Created by Golan/Maxim Shoustin on 5/17/16.
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
@@ -10,14 +10,25 @@
 #import <Analytics/SEGAnalytics.h>
 #import <AppsFlyerLib/AppsFlyerTracker.h>
 
+@protocol SEGAppsFlyerTrackerDelegate <AppsFlyerTrackerDelegate>
+
+@end
 
 @interface SEGAppsFlyerIntegration : NSObject <SEGIntegration, AppsFlyerTrackerDelegate>
 
 @property (nonatomic, strong) NSDictionary *settings;
 @property (nonatomic, strong) AppsFlyerTracker *appsflyer;
 @property (nonatomic, strong) SEGAnalytics *analytics;
+@property (unsafe_unretained, nonatomic) id<SEGAppsFlyerTrackerDelegate> segDelegate;
+
+- (instancetype)initWithSettings:(NSDictionary *)settings
+                   withAnalytics:(SEGAnalytics *) analytics;
+
+- (instancetype)initWithSettings:(NSDictionary *)settings
+                   withAnalytics:(SEGAnalytics *)analytics
+                andDelegate:(id<AppsFlyerTrackerDelegate>) delegate;
 
 
-- (instancetype)initWithSettings:(NSDictionary *)settings withAnalytics:(SEGAnalytics *) analytics;
 - (void) trackLaunch;
 @end
+

--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
@@ -26,7 +26,7 @@
         if ([self trackAttributionData]) {
             self.appsflyer.delegate = self;
         }
-        self.appsflyer.isDebug = YES;
+        //self.appsflyer.isDebug = YES;
     }
     return self;
 }

--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
@@ -2,12 +2,13 @@
 //  SEGAppsFlyerIntegration.m
 //  AppsFlyerSegmentiOS
 //
-//  Created by Golan on 5/17/16.
+//  Created by Golan/Maxim Shoustin on 5/17/16.
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
 #import "SEGAppsFlyerIntegration.h"
 #import <Analytics/SEGAnalyticsUtils.h>
+#import "SEGAppsFlyerIntegrationFactory.h"
 
 @implementation SEGAppsFlyerIntegration
 
@@ -25,8 +26,18 @@
         if ([self trackAttributionData]) {
             self.appsflyer.delegate = self;
         }
+        self.appsflyer.isDebug = YES;
     }
     return self;
+}
+
+
+- (instancetype)initWithSettings:(NSDictionary *)settings
+                   withAnalytics:(SEGAnalytics *)analytics
+                andDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate
+{
+    self.segDelegate = delegate;
+    return [self initWithSettings:settings withAnalytics:analytics];
 }
 
 - (instancetype)initWithSettings:(NSDictionary *)settings withAppsflyer:(AppsFlyerTracker *)aAppsflyer {
@@ -135,7 +146,13 @@
     return nil;
 }
 
--(void)onConversionDataReceived:(NSDictionary *)installData {
+-(void)onConversionDataReceived:(NSDictionary *)installData
+{
+    
+    if(self.segDelegate)
+    {
+        [self.segDelegate onConversionDataReceived:installData];
+    }
     
     NSString *const key = @"AF_Install_Attr_Sent";
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -165,9 +182,31 @@
     }
 }
 
-
--(void)onConversionDataRequestFailure:(NSError *) error {
+-(void)onConversionDataRequestFailure:(NSError *) error
+{
+    if(self.segDelegate)
+    {
+        [self.segDelegate onConversionDataRequestFailure:error];
+    }
     SEGLog(@"[Appsflyer] onConversionDataRequestFailure:%@]", error);
+}
+
+- (void) onAppOpenAttribution:(NSDictionary*) attributionData
+{
+    if(self.segDelegate)
+    {
+        [self.segDelegate onAppOpenAttribution:attributionData];
+    }
+    SEGLog(@"[Appsflyer] onAppOpenAttribution data: %@", attributionData);
+}
+
+- (void) onAppOpenAttributionFailure:(NSError *)error
+{
+    if(self.segDelegate)
+    {
+        [self.segDelegate onAppOpenAttributionFailure:error];
+    }
+    SEGLog(@"[Appsflyer] onAppOpenAttribution failure data: %@", error);
 }
 
 - (BOOL)trackAttributionData

--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegrationFactory.h
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegrationFactory.h
@@ -2,15 +2,20 @@
 //  SEGAppsFlyerIntegrationFactory.h
 //  AppsFlyerSegmentiOS
 //
-//  Created by Golan on 5/17/16.
+//  Created by Golan/Maxim Shoustin on 5/17/16.
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
+#import "SEGAppsFlyerIntegration.h"
+
 
 @interface SEGAppsFlyerIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 + (instancetype)instance;
++ (instancetype)createWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate;
+
+@property (unsafe_unretained, nonatomic) id<SEGAppsFlyerTrackerDelegate> delegate;
 
 @end

--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegrationFactory.m
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegrationFactory.m
@@ -2,12 +2,11 @@
 //  SEGAppsFlyerIntegrationFactory.m
 //  AppsFlyerSegmentiOS
 //
-//  Created by Golan on 5/17/16.
+//  Created by Golan/Maxim Shoustin on 5/17/16.
 //  Copyright © 2016 AppsFlyer. All rights reserved.
 //
 
 #import "SEGAppsFlyerIntegrationFactory.h"
-#import "SEGAppsFlyerIntegration.h"
 
 
 @implementation SEGAppsFlyerIntegrationFactory : NSObject
@@ -17,7 +16,7 @@
     static dispatch_once_t once;
     static SEGAppsFlyerIntegrationFactory *sharedInstance;
     dispatch_once(&once, ^{
-        sharedInstance = [[self alloc] init];
+        sharedInstance = [[self alloc] initWithLaunchDelegate:nil];
     });
     return sharedInstance;
 }
@@ -28,9 +27,24 @@
     return self;
 }
 
+- (instancetype)initWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate
+{
+    if (self = [super init]) {
+        self.delegate = delegate;
+    }
+    return self;
+}
+
+
++ (instancetype)createWithLaunchDelegate:(id<SEGAppsFlyerTrackerDelegate>) delegate
+{
+    return [[self alloc] initWithLaunchDelegate:delegate];
+}
+
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics];
+    return [[SEGAppsFlyerIntegration alloc] initWithSettings:settings withAnalytics:analytics
+                                            andDelegate:self.delegate];
 }
 
 - (NSString *)key


### PR DESCRIPTION
please check:

-  segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
-  segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
-  segment-appsflyer-ios/Classes/SEGAppsFlyerIntegrationFactory.h
-  segment-appsflyer-ios/Classes/SEGAppsFlyerIntegrationFactory.m 

----
User wants to leverage onConversionData's response to access attribution data However, since we are assigning the delegate to self in the iOS wrapper, user is not able to access the attribution data response.
Code:
https://github.com/AppsFlyerSDK/segment-appsflyer-ios/blob/master/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m#L25-L26

So the fix was to create additional Segment delegate a.e.

```
@protocol SEGAppsFlyerTrackerDelegate <AppsFlyerTrackerDelegate>
@end
```

and to pass it through Factory