### PR TITLE
Fix `use_frameworks!` interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,31 +30,6 @@ To install the segment-appsflyer-ios integration, simply add this line to your [
 ```ruby
 pod 'segment-appsflyer-ios'
 ```
-### <a id="troubleshooting-inst">Troubleshooting
-
-For users who are unable to bundle static libraries as dependencies (Swift project for example)
-     you can choose `StaticLibWorkaround` subspec, but be sure to include `AppsFlyerFramework` to  in your Podfile:
-
-Example:
-     
-```ruby
-  pod 'AppsFlyerFramework'
-  pod 'segment-appsflyer-ios/StaticLibWorkaround'
-```
-
-Next step, add manually 5 files to your project (located under `<YOUR_APP>/Pods/segment-appsflyer-ios/segment-appsflyer-ios/Classes`):
-  
- - `SEGAppsFlyerIntegration.h`
- - `SEGAppsFlyerIntegration.m`
- - `SEGAppsFlyerIntegrationFactory.h`
- - `SEGAppsFlyerIntegrationFactory.m`
- - `SegmentAppsFlyeriOS.h`
-
-Xcode will ask you to generate `<YOUR_APP_NAME>-Bridging-Header.h`
-Add to this file `#import "SEGAppsFlyerIntegrationFactory.h"`
-
-For more details follow the instructions from Apple [here](https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html).
-
 
 ## <a id="usage"> Usage
 

--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -16,18 +16,10 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
   s.requires_arc = true
+  s.static_framework = true
 
   s.dependency 'Analytics', '~> 3.5'
   s.source_files = 'segment-appsflyer-ios/Classes/**/*'
   s.ios.dependency 'AppsFlyerFramework', '~> 4' 
   s.tvos.dependency 'AppsFlyerTvOsLib', '~> 4'    
-
-
-  s.subspec 'StaticLibWorkaround' do |workaround|
-    # For users who are unable to bundle static libraries as dependencies
-    # you can choose this subspec, but be sure to include the following in your Podfile:
-    # pod 'AppsFlyerFramework','~> 4'
-    # Please manually add the following file preserved by Cocoapods to your xcodeproj file
-    workaround.preserve_paths = 'segment-appsflyer-ios/Classes/**/*'
-  end
 end


### PR DESCRIPTION
Currently `StaticLibWorkaround` is needed to fix issues with transitive static libraries and `use_frameworks!`.

Now that CocoaPods supports the `static_framework` setting we don't need it anymore and the Pod should act the same way - `use_frameworks!` or not.