### PR TITLE
Removed analytics version pinning

### DIFF
--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "segment-appsflyer-ios"
-  s.version          = "5.2.0"
+  s.version          = "5.2.1"
   s.summary          = "AppsFlyer Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.static_framework = true
 
-  s.dependency 'Analytics', '~> 3.7'
+  s.dependency 'Analytics'
   s.source_files = 'segment-appsflyer-ios/Classes/**/*'
   s.ios.dependency 'AppsFlyerFramework', '~> 5.2.0' 
   s.tvos.dependency 'AppsFlyerFramework', '~> 5.2.0'    


### PR DESCRIPTION
This allows customers to use the AppsFlyer integration in our new 4.x series builds of Analytics-iOS.  Destination compatibility will be maintained with no changes necessary.