### PR TITLE
Override segment event

### DIFF
--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.h
@@ -12,6 +12,10 @@
 
 @protocol SEGAppsFlyerLibDelegate <AppsFlyerLibDelegate>
 
+@optional
+
+- (BOOL)shouldSendSegmentInstallAttributedEvent;
+
 @end
 
 @interface SEGAppsFlyerIntegration : NSObject <SEGIntegration, AppsFlyerLibDelegate>


### PR DESCRIPTION
Issue: 
If a developer wants to send a different event to Segment or add other properties to the `Install Attributed` event then there is no way to do this.

Solution:
By adding another delegate method we can override the sending of the event so that the `SEGAppsFlyerLib` delegate can send the event instead.

Other potential solutions:
We add in a delegate method that asks for additional properties, and then add these to the NSMutableDictionary before sending them to Segment