### PR TITLE
Update iOS SDK to 6.2.3

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/Carthage/appsflyer-ios.json" "6.2.1"
+binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/Carthage/appsflyer-ios.json" "6.2.3"
 github "segmentio/analytics-ios" "4.1.3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # AppsFlyer integration for Segment.
 
-## This is a Segment wrapper for AppsFlyer SDK that is built with iOS SDK v6.2.0. 
+## This is a Segment wrapper for AppsFlyer SDK that is built with iOS SDK v6.2.3. 
 
 [![Version](https://img.shields.io/cocoapods/v/segment-appsflyer-ios.svg?style=flat)](http://cocoapods.org/pods/segment-appsflyer-ios)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
@@ -42,12 +42,12 @@ To install the segment-appsflyer-ios integration:
 
 **Production** version: 
 ```ruby
-pod 'segment-appsflyer-ios', '6.2.0'
+pod 'segment-appsflyer-ios', '6.2.3'
 ```
 
 **Strict mode SDK** version: 
 ```ruby
-pod 'segment-appsflyer-ios/Strict', '6.2.0'
+pod 'segment-appsflyer-ios/Strict', '6.2.3'
 ```
 Use the strict mode SDK to completely remove IDFA collection functionality and AdSupport framework dependencies (for example, when developing apps for kids).
 
@@ -59,7 +59,7 @@ Use the strict mode SDK to completely remove IDFA collection functionality and A
 
 **Production** version: 
 ```ogdl
-github "AppsFlyerSDK/segment-appsflyer-ios" "6.2.0"
+github "AppsFlyerSDK/segment-appsflyer-ios" "6.2.3"
 ```
 
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+### 6.2.3
+* Updated iOS SDK to v6.2.3
+
 ### 6.2.0
 * Updated iOS SDK to v6.2.0
 

--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "segment-appsflyer-ios"
-  s.version          = "6.2.0"
+  s.version          = "6.2.3"
   s.summary          = "AppsFlyer Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC
@@ -23,15 +23,15 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Main'
   s.subspec 'Main' do |ss|
-    ss.ios.dependency 'AppsFlyerFramework', '~> 6.2.0'
-    ss.tvos.dependency 'AppsFlyerFramework', '~> 6.2.0'
+    ss.ios.dependency 'AppsFlyerFramework', '~> 6.2.3'
+    ss.tvos.dependency 'AppsFlyerFramework', '~> 6.2.3'
   end
   
   s.subspec 'Strict' do |ss|
-    ss.ios.dependency 'AppsFlyerFramework/Strict', '~> 6.2.0'
+    ss.ios.dependency 'AppsFlyerFramework/Strict', '~> 6.2.3'
   end
 
   s.subspec 'MacCatalyst' do |ss|
-    ss.ios.dependency 'AppsFlyerFramework/MacCatalyst', '~> 6.2.0'
+    ss.ios.dependency 'AppsFlyerFramework/MacCatalyst', '~> 6.2.3'
   end
 end


### PR DESCRIPTION
AppsFlyer recently [released 6.2.3 ](https://support.appsflyer.com/hc/en-us/articles/115001224823-AppsFlyer-iOS-SDK-release-notes) which fixes a bug related to SKAdNetwork updateConversionValue. This PR updates the iOS SDK to 6.2.3