### PR TITLE
Fix subspecs not including source files

### DIFF
--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -19,19 +19,21 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'Analytics'
-  s.source_files = 'segment-appsflyer-ios/Classes/**/*'
 
   s.default_subspecs = 'Main'
   s.subspec 'Main' do |ss|
     ss.ios.dependency 'AppsFlyerFramework', '~> 6.2.6'
     ss.tvos.dependency 'AppsFlyerFramework', '~> 6.2.6'
+    ss.source_files = 'segment-appsflyer-ios/Classes/**/*'
   end
   
   s.subspec 'Strict' do |ss|
     ss.ios.dependency 'AppsFlyerFramework/Strict', '~> 6.2.6'
+    ss.source_files = 'segment-appsflyer-ios/Classes/**/*'
   end
 
   s.subspec 'MacCatalyst' do |ss|
     ss.ios.dependency 'AppsFlyerFramework/MacCatalyst', '~> 6.2.6'
+    ss.source_files = 'segment-appsflyer-ios/Classes/**/*'
   end
 end


### PR DESCRIPTION
This fixes https://github.com/AppsFlyerSDK/segment-appsflyer-ios/issues/57

The issue is that source files are not included in the project when a subspec is used, like `pod 'segment-appsflyer-ios/Strict', '6.2.6'`.

It looks like the cause is that `source_files` from main spec is not inherited by the subspecs and it should be duplicated in each subspec rather than being defined once in main spec (like it's done in https://github.com/Appboy/appboy-segment-ios/blob/0bf986/Segment-Appboy.podspec#L36 for example).